### PR TITLE
Add Code Documentations

### DIFF
--- a/contracts/DM2E.sol
+++ b/contracts/DM2E.sol
@@ -5,22 +5,36 @@ import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
 
+/**
+ * DM2E is an utility token that is not capped.
+ * The total supply of the token will be maintained
+ * by the MINER_ROLE and BURNER_ROLE accounts.
+ * The MINER_ROLE account will mint new tokens
+ * according to the economic demands such as
+ * wallet count, transaction count, etc.
+ * The BURNER_ROLE account will burn tokens when
+ * the token is used to pay for the service,
+ * the token price is too low, etc.
+ */
 contract DM2E is AccessControlEnumerable, ERC20Pausable, ERC20Burnable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
     constructor() ERC20("DM2E", "DM2E") {
+        // All roles are granted to the deployer.
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
         _grantRole(BURNER_ROLE, msg.sender);
     }
 
+    // Only the MINTER_ROLE account can mint new tokens up to the CAP_AMOUNT.
     function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
         _mint(to, amount);
     }
 
+    // Only the PAUSER_ROLE account can pause and unpause the token.
     function pause() external onlyRole(PAUSER_ROLE) {
         _pause();
     }
@@ -29,6 +43,7 @@ contract DM2E is AccessControlEnumerable, ERC20Pausable, ERC20Burnable {
         _unpause();
     }
 
+    // Only the BURNER_ROLE account can burn tokens.
     function burn(uint256 amount) public override onlyRole(BURNER_ROLE) {
         super.burn(amount);
     }
@@ -40,6 +55,7 @@ contract DM2E is AccessControlEnumerable, ERC20Pausable, ERC20Burnable {
         super.burnFrom(account, amount);
     }
 
+    // When the token is paused, no transfer is allowed.
     function _beforeTokenTransfer(
         address from,
         address to,
@@ -48,6 +64,7 @@ contract DM2E is AccessControlEnumerable, ERC20Pausable, ERC20Burnable {
         super._beforeTokenTransfer(from, to, amount);
     }
 
+    // The last member of a role cannot be revoked.
     function _revokeRole(
         bytes32 role,
         address account

--- a/contracts/DM2P.sol
+++ b/contracts/DM2P.sol
@@ -6,6 +6,16 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Capped.sol";
 
+/**
+ * DM2P is a governance token that is capped.
+ * The CAP_AMOUNT is 1e10 * 1e18 (10 Billion).
+ * The MINTER_ROLE account can mint new tokens up to
+ * the CAP_AMOUNT.
+ * Under normal circumstances, all tokens will be
+ * minted when the token contract is deployed,
+ * and no further operations will be performed to
+ * change the total suppy.
+ */
 contract DM2P is
     AccessControlEnumerable,
     ERC20Pausable,
@@ -19,12 +29,14 @@ contract DM2P is
     uint256 public constant CAP_AMOUNT = 1e10 * 1e18;
 
     constructor() ERC20("DM2P", "DM2P") ERC20Capped(CAP_AMOUNT) {
+        // All roles are granted to the deployer.
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
         _grantRole(BURNER_ROLE, msg.sender);
     }
 
+    // Only the MINTER_ROLE account can mint new tokens up to the CAP_AMOUNT.
     function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
         _mint(to, amount);
     }
@@ -36,6 +48,7 @@ contract DM2P is
         super._mint(account, amount);
     }
 
+    // Only the PAUSER_ROLE account can pause and unpause the token.
     function pause() external onlyRole(PAUSER_ROLE) {
         _pause();
     }
@@ -44,6 +57,7 @@ contract DM2P is
         _unpause();
     }
 
+    // Only the BURNER_ROLE account can burn tokens.
     function burn(uint256 amount) public override onlyRole(BURNER_ROLE) {
         super.burn(amount);
     }
@@ -55,6 +69,7 @@ contract DM2P is
         super.burnFrom(account, amount);
     }
 
+    // When the token is paused, no transfer is allowed.
     function _beforeTokenTransfer(
         address from,
         address to,
@@ -63,6 +78,7 @@ contract DM2P is
         super._beforeTokenTransfer(from, to, amount);
     }
 
+    // The last member of a role cannot be revoked.
     function _revokeRole(
         bytes32 role,
         address account


### PR DESCRIPTION
Add some code documentations

| Findings | Status | Commit Hash | Description |
|--|--|--|--|
| Best Practices | Acknowledged | 52fff75788f994d883431e32589258552a973544 | Add some code documentations. CAP_AMOUNT is still defined by using a literal value (1e18) because it should be compile-time constant. |